### PR TITLE
换用多说镜像，解决Gravatar被墙头像不显示的问题。

### DIFF
--- a/lib/func/comm.func.php
+++ b/lib/func/comm.func.php
@@ -12,7 +12,7 @@ function get_last_port(){
 
 //Gravatar
 function get_gravatar( $email, $s = 80, $d = 'mm', $r = 'g', $img = false, $atts = array() ) {
-    $url = 'https://secure.gravatar.com/avatar/';
+    $url = 'http://gravatar.duoshuo.com/avatar/';
     $url .= md5( strtolower( trim( $email ) ) );
     $url .= "?s=$s&d=$d&r=$r";
     if ( $img ) {


### PR DESCRIPTION
换用多说镜像，解决Gravatar被墙头像不显示的问题。