### PR TITLE
更正语言代码为zh

### DIFF
--- a/header.php
+++ b/header.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh">
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
谷歌浏览器总是自动翻译，后来才发现header.php里的lang="en"语言代码为英文，现在更正为lang="zh"  


按这个
HTML 语言代码参考手册
http://www.w3school.com.cn/tags/html_ref_language_codes.asp
来改的！