### PR TITLE
再次优化，修复之前的一些小问题，添加本地验证输入，从而减少不必要的请求连接。

### DIFF
--- a/admin/login.php
+++ b/admin/login.php
@@ -53,7 +53,7 @@ require_once '../lib/config.php';
                 </div><!-- /.col -->
             </div>
                 
-            <div id="msg-success" class="alert alert-info alert-dismissable" style="border: 1px solid rgb(50, 163, 213); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -60px !important; position: fixed !important; display: none;">
+            <div id="msg-success" class="alert alert-info alert-dismissable"style="border: 1px solid rgb(50, 163, 213); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -60px !important; position: fixed !important; display: none;">
                 <button type="button" class="close" id="ok-close" aria-hidden="true">&times;</button>
                 <h4><i class="icon fa fa-info"></i> 登录成功!</h4>
                <p id="msg-success-p"></p>
@@ -120,21 +120,21 @@ require_once '../lib/config.php';
             {
                 var msg_id=0;
                 if($("#email").val().length==0){
+                    id_name="#email";
                     msg_out("请输入邮箱","error");
-                    $("#email").focus();
                     msg_id=1;
                     return false;
                 }
                 var email_reg = /^([a-zA-Z0-9]+[_|\_|\.]?)*[a-zA-Z0-9]+@([a-zA-Z0-9]+[_|\_|\.]?)*[a-zA-Z0-9]+\.[a-zA-Z]{2,3}$/;
                 if(!email_reg.test($("#email").val())) {
+                    id_name="#email";
                     msg_out("请输入有效的邮箱！","error");
-                    $("#email").focus();
                     msg_id=1;
                     return false;
                 }
                 if($("#passwd").val().length==0){
+                    id_name="#passwd";
                     msg_out("请输入密码","error");
-                    $("#passwd").focus();
                     msg_id=1;
                     return false;
                 }
@@ -147,7 +147,7 @@ require_once '../lib/config.php';
                 if($("#msg-error-p").eq(0)[0].innerHTML=="邮箱或者密码错误" 
                     || $("#msg-error-p").eq(0)[0].innerHTML=="邮箱或者密码错误，请重新输入！"){
                      if($("#passwd").val()==inpasswd && $("#email").val()==inemail){
-                    	$("#passwd").focus();
+                        id_name="#passwd";
                         msg_out("邮箱或者密码错误，请重新输入！","error");
                         msg_id=1;
                         return false;
@@ -161,6 +161,7 @@ require_once '../lib/config.php';
                     $("#msg-"+msgcss).hide(10);
                     $("#msg-"+msgcss).show(100);
                     $("#msg-"+msgcss+"-p").html(msgout);
+                    $(id_name).focus();
             }
         $("html").keydown(function(event){
             if(event.keyCode==13){
@@ -175,6 +176,7 @@ require_once '../lib/config.php';
         });
         $("#error-close").click(function(){
             $("#msg-error").hide(100);
+            $(id_name).focus();
         });
     })
 </script>

--- a/admin/login.php
+++ b/admin/login.php
@@ -53,13 +53,13 @@ require_once '../lib/config.php';
                 </div><!-- /.col -->
             </div>
                 
-            <div id="msg-success" class="alert alert-info alert-dismissable" style="display: none;">
+            <div id="msg-success" class="alert alert-info alert-dismissable" style="position: fixed; width: 25%; text-align: center; display: none;">
                 <button type="button" class="close" id="ok-close" aria-hidden="true">&times;</button>
                 <h4><i class="icon fa fa-info"></i> 登录成功!</h4>
                <p id="msg-success-p"></p>
             </div>
     
-            <div id="msg-error" class="alert alert-danger" style="display: none;">
+            <div id="msg-error" class="alert alert-danger" style="position: fixed; width: 25%; text-align: center; display: none;">
                 <button type="button" class="close" id="error-close" aria-hidden="true">&times;</button>
                 <h4><i class="icon fa fa-warning"></i> 出错了!</h4>
                 <p id="msg-error-p"></p>
@@ -139,14 +139,15 @@ require_once '../lib/config.php';
                     return false;
                 }
                 if($("#msg-success-p").eq(0)[0].innerHTML=="欢迎回来"
-                    || $("#msg-success-p").eq(0)[0].innerHTML=="你已成功登录，如果页面不跳转，请刷新！"){
-                        msg_out("你已成功登录，如果页面不跳转，请刷新！","success");
+                    || $("#msg-success-p").eq(0)[0].innerHTML=="你已成功登录！"){
+                        msg_out("你已成功登录！","success");
                         msg_id=1;
-                        $("#msg-error-p").html("");
+                        $("#msg-error-p").html(null);
                 }
                 if($("#msg-error-p").eq(0)[0].innerHTML=="邮箱或者密码错误" 
                     || $("#msg-error-p").eq(0)[0].innerHTML=="邮箱或者密码错误，请重新输入！"){
                      if($("#passwd").val()==inpasswd && $("#email").val()==inemail){
+                    	$("#passwd").focus();
                         msg_out("邮箱或者密码错误，请重新输入！","error");
                         msg_id=1;
                         return false;

--- a/admin/login.php
+++ b/admin/login.php
@@ -166,6 +166,9 @@ require_once '../lib/config.php';
             if(event.keyCode==13){
                 logincheck();
             }
+            if(event.keyCode==27){
+                error_close();
+            }
         });
         $("#login").click(function(){
             logincheck();
@@ -174,9 +177,17 @@ require_once '../lib/config.php';
             $("#msg-success").hide(100);
         });
         $("#msg-error").click(function(){
-            $("#msg-error").hide(100);
-            $(id_name).focus();
+            error_close();
         });
+        function error_close(){
+            if($("#msg-error").css('display')=="block"){
+                $("#msg-error").hide(100);
+                $(id_name).focus();
+                if(id_name=="#email"){
+                    $(id_name).select();
+                }
+            }
+        }
     })
 </script>
 </body>

--- a/admin/login.php
+++ b/admin/login.php
@@ -59,7 +59,7 @@ require_once '../lib/config.php';
                <p id="msg-success-p"></p>
             </div>
     
-            <div id="msg-error" class="alert alert-warning alert-dismissable" style="display: none;">
+            <div id="msg-error" class="alert alert-danger" style="display: none;">
                 <button type="button" class="close" id="error-close" aria-hidden="true">&times;</button>
                 <h4><i class="icon fa fa-warning"></i> 出错了!</h4>
                 <p id="msg-error-p"></p>
@@ -82,8 +82,6 @@ require_once '../lib/config.php';
             increaseArea: '20%' // optional
         });
     });
-    // $("#msg-error").hide(100);
-    // $("#msg-success").hide(100);
 </script>
 <script>
     $(document).ready(function(){
@@ -114,14 +112,62 @@ require_once '../lib/config.php';
                      $("#msg-error-p").html("发生错误："+jqXHR.status);
                 }
             });
+            
+            inemail=$("#email").val();
+            inpasswd=$("#passwd").val();
         }
+        function logincheck()
+            {
+                var msg_id=0;
+                if($("#email").val().length==0){
+                    msg_out("请输入邮箱","error");
+                    $("#email").focus();
+                    msg_id=1;
+                    return false;
+                }
+                var email_reg = /^([a-zA-Z0-9]+[_|\_|\.]?)*[a-zA-Z0-9]+@([a-zA-Z0-9]+[_|\_|\.]?)*[a-zA-Z0-9]+\.[a-zA-Z]{2,3}$/;
+                if(!email_reg.test($("#email").val())) {
+                    msg_out("请输入有效的邮箱！","error");
+                    $("#email").focus();
+                    msg_id=1;
+                    return false;
+                }
+                if($("#passwd").val().length==0){
+                    msg_out("请输入密码","error");
+                    $("#passwd").focus();
+                    msg_id=1;
+                    return false;
+                }
+                if($("#msg-success-p").eq(0)[0].innerHTML=="欢迎回来"
+                    || $("#msg-success-p").eq(0)[0].innerHTML=="你已成功登录，如果页面不跳转，请刷新！"){
+                        msg_out("你已成功登录，如果页面不跳转，请刷新！","success");
+                        msg_id=1;
+                        $("#msg-error-p").html("");
+                }
+                if($("#msg-error-p").eq(0)[0].innerHTML=="邮箱或者密码错误"
+                    || $("#msg-error-p").eq(0)[0].innerHTML=="邮箱或者密码错误，请重新输入！","error"){
+                     if($("#passwd").val()==inpasswd && $("#email").val()==inemail){
+                        msg_out("邮箱或者密码错误，请重新输入！");
+                        msg_id=1;
+                        return false;
+                    }
+                }
+                if(msg_id==0){
+                    login();
+                }
+            }
+            function msg_out(msgout,msgcss){
+                    $("#msg-"+msgcss).hide(10);
+                    $("#msg-"+msgcss).show(100);
+                    $("#msg-"+msgcss+"-p").html(msgout);
+            }
         $("html").keydown(function(event){
             if(event.keyCode==13){
-                login();
+                logincheck();
             }
         });
         $("#login").click(function(){
-            login();
+            logincheck();
         });
         $("#ok-close").click(function(){
             $("#msg-success").hide(100);

--- a/admin/login.php
+++ b/admin/login.php
@@ -53,13 +53,13 @@ require_once '../lib/config.php';
                 </div><!-- /.col -->
             </div>
                 
-            <div id="msg-success" class="alert alert-info alert-dismissable"style="border: 1px solid rgb(50, 163, 213); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -60px !important; position: fixed !important; display: none;">
+            <div id="msg-success" class="alert alert-info alert-dismissable"style="border: 1px solid rgb(50, 163, 213); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -118px !important; position: fixed !important; display: none;">
                 <button type="button" class="close" id="ok-close" aria-hidden="true">&times;</button>
                 <h4><i class="icon fa fa-info"></i> 登录成功!</h4>
                <p id="msg-success-p"></p>
             </div>
     
-            <div id="msg-error" class="alert alert-danger" style="border: 1px solid rgb(255, 0, 0); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -60px !important; position: fixed !important; display: none;">
+            <div id="msg-error" class="alert alert-danger" style="border: 1px solid rgb(255, 0, 0); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -118px !important; position: fixed !important; display: none;">
                 <button type="button" class="close" id="error-close" aria-hidden="true">&times;</button>
                 <h4><i class="icon fa fa-warning"></i> 出错了!</h4>
                 <p id="msg-error-p"></p>

--- a/admin/login.php
+++ b/admin/login.php
@@ -53,13 +53,13 @@ require_once '../lib/config.php';
                 </div><!-- /.col -->
             </div>
                 
-            <div id="msg-success" class="alert alert-info alert-dismissable"style="border: 1px solid rgb(50, 163, 213); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -118px !important; position: fixed !important; display: none;">
+            <div id="msg-success" class="alert alert-info alert-dismissable"style="border: 1px solid rgb(50, 163, 213); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -60px !important; position: fixed !important; display: none;">
                 <button type="button" class="close" id="ok-close" aria-hidden="true">&times;</button>
                 <h4><i class="icon fa fa-info"></i> 登录成功!</h4>
                <p id="msg-success-p"></p>
             </div>
     
-            <div id="msg-error" class="alert alert-danger" style="border: 1px solid rgb(255, 0, 0); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -118px !important; position: fixed !important; display: none;">
+            <div id="msg-error" class="alert alert-danger" style="border: 1px solid rgb(255, 0, 0); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -60px !important; position: fixed !important; display: none;">
                 <button type="button" class="close" id="error-close" aria-hidden="true">&times;</button>
                 <h4><i class="icon fa fa-warning"></i> 出错了!</h4>
                 <p id="msg-error-p"></p>

--- a/admin/login.php
+++ b/admin/login.php
@@ -32,7 +32,7 @@ require_once '../lib/config.php';
 
             <form>
             <div class="form-group has-feedback">
-                <input id="email" name="Email" type="text" class="form-control" placeholder="邮箱"/>
+                <input id="email" name="Email" type="text" class="form-control" autofocus="autofocus" placeholder="邮箱"/>
                 <span  class="glyphicon glyphicon-envelope form-control-feedback"></span>
             </div>
             <div class="form-group has-feedback">
@@ -59,7 +59,7 @@ require_once '../lib/config.php';
                <p id="msg-success-p"></p>
             </div>
     
-            <div id="msg-error" class="alert alert-danger" style="border: 1px solid rgb(255, 0, 0); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -60px !important; position: fixed !important; display: none;">
+            <div id="msg-error" class="alert alert-danger" title="点击关闭" style="border: 1px solid rgb(255, 0, 0); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -60px !important; position: fixed !important; display: none;">
                 <button type="button" class="close" id="error-close" aria-hidden="true">&times;</button>
                 <h4><i class="icon fa fa-warning"></i> 出错了!</h4>
                 <p id="msg-error-p"></p>
@@ -161,7 +161,6 @@ require_once '../lib/config.php';
                     $("#msg-"+msgcss).hide(10);
                     $("#msg-"+msgcss).show(100);
                     $("#msg-"+msgcss+"-p").html(msgout);
-                    $(id_name).focus();
             }
         $("html").keydown(function(event){
             if(event.keyCode==13){
@@ -174,7 +173,7 @@ require_once '../lib/config.php';
         $("#ok-close").click(function(){
             $("#msg-success").hide(100);
         });
-        $("#error-close").click(function(){
+        $("#msg-error").click(function(){
             $("#msg-error").hide(100);
             $(id_name).focus();
         });

--- a/admin/login.php
+++ b/admin/login.php
@@ -53,13 +53,13 @@ require_once '../lib/config.php';
                 </div><!-- /.col -->
             </div>
                 
-            <div id="msg-success" class="alert alert-info alert-dismissable" style="position: fixed; width: 25%; text-align: center; display: none;">
+            <div id="msg-success" class="alert alert-info alert-dismissable" style="border: 1px solid rgb(50, 163, 213); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -60px !important; position: fixed !important; display: none;">
                 <button type="button" class="close" id="ok-close" aria-hidden="true">&times;</button>
                 <h4><i class="icon fa fa-info"></i> 登录成功!</h4>
                <p id="msg-success-p"></p>
             </div>
     
-            <div id="msg-error" class="alert alert-danger" style="position: fixed; width: 25%; text-align: center; display: none;">
+            <div id="msg-error" class="alert alert-danger" style="border: 1px solid rgb(255, 0, 0); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -60px !important; position: fixed !important; display: none;">
                 <button type="button" class="close" id="error-close" aria-hidden="true">&times;</button>
                 <h4><i class="icon fa fa-warning"></i> 出错了!</h4>
                 <p id="msg-error-p"></p>

--- a/admin/login.php
+++ b/admin/login.php
@@ -144,10 +144,10 @@ require_once '../lib/config.php';
                         msg_id=1;
                         $("#msg-error-p").html("");
                 }
-                if($("#msg-error-p").eq(0)[0].innerHTML=="邮箱或者密码错误"
-                    || $("#msg-error-p").eq(0)[0].innerHTML=="邮箱或者密码错误，请重新输入！","error"){
+                if($("#msg-error-p").eq(0)[0].innerHTML=="邮箱或者密码错误" 
+                    || $("#msg-error-p").eq(0)[0].innerHTML=="邮箱或者密码错误，请重新输入！"){
                      if($("#passwd").val()==inpasswd && $("#email").val()==inemail){
-                        msg_out("邮箱或者密码错误，请重新输入！");
+                        msg_out("邮箱或者密码错误，请重新输入！","error");
                         msg_id=1;
                         return false;
                     }

--- a/user/login.php
+++ b/user/login.php
@@ -32,7 +32,7 @@ require_once '../lib/config.php';
 
             <form>
             <div class="form-group has-feedback">
-                <input id="email" name="Email" type="text" class="form-control" placeholder="邮箱"/>
+                <input id="email" name="Email" type="text" class="form-control" autofocus="autofocus" placeholder="邮箱"/>
                 <span  class="glyphicon glyphicon-envelope form-control-feedback"></span>
             </div>
             <div class="form-group has-feedback">
@@ -57,7 +57,7 @@ require_once '../lib/config.php';
                 <h4><i class="icon fa fa-info"></i> 登录成功!</h4>
                 <p id="msg-success-p"></p>
             </div>
-            <div id="msg-error" class="alert alert-danger" style="border: 1px solid rgb(255, 0, 0); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -60px !important; position: fixed !important; display: none;">
+            <div id="msg-error" class="alert alert-danger" title="点击关闭" style="border: 1px solid rgb(255, 0, 0); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -60px !important; position: fixed !important; display: none;">
                 <button type="button" class="close" id="error-close" aria-hidden="true">&times;</button>
                 <h4><i class="icon fa fa-warning"></i> 出错了!</h4>
                 <p id="msg-error-p"></p>
@@ -160,12 +160,6 @@ require_once '../lib/config.php';
                 }
             }
             function msg_out(msgout,msgcss){
-                // if($("#msg-error").css("display")=="block"){
-                //     msgcss="error";
-                // }
-                // if($("#msg-success").css("display")=="block"){
-                //     msgcss="success";
-                // }
                     $("#msg-"+msgcss).hide(10);
                     $("#msg-"+msgcss).show(100);
                     $("#msg-"+msgcss+"-p").html(msgout);
@@ -183,7 +177,7 @@ require_once '../lib/config.php';
          $("#ok-close").click(function(){
             $("#msg-success").hide(100);
         });
-        $("#error-close").click(function(){
+        $("#msg-error").click(function(){
             $("#msg-error").hide(100);
             $(id_name).focus();
         });

--- a/user/login.php
+++ b/user/login.php
@@ -163,12 +163,14 @@ require_once '../lib/config.php';
                     $("#msg-"+msgcss).hide(10);
                     $("#msg-"+msgcss).show(100);
                     $("#msg-"+msgcss+"-p").html(msgout);
-                    $(id_name).focus();
             }
        
         $("html").keydown(function(event){
             if(event.keyCode==13){
                 logincheck();
+            }
+            if(event.keyCode==27){
+                error_close();
             }
         });
         $("#login").click(function(){
@@ -178,9 +180,17 @@ require_once '../lib/config.php';
             $("#msg-success").hide(100);
         });
         $("#msg-error").click(function(){
-            $("#msg-error").hide(100);
-            $(id_name).focus();
+            error_close();
         });
+        function error_close(){
+            if($("#msg-error").css('display')=="block"){
+                $("#msg-error").hide(100);
+                $(id_name).focus();
+                if(id_name=="#email"){
+                    $(id_name).select();
+                }
+            }
+        }
     })
 </script>
 </body>

--- a/user/login.php
+++ b/user/login.php
@@ -122,20 +122,20 @@ require_once '../lib/config.php';
             {
                 var msg_id=0,msgcss="error";
                 if($("#email").val().length==0){
-                    $("#email").focus();
+                    id_name="#email";
                     msg_out("请输入邮箱","error");
                     msg_id=1;
                     return false;
                 }
                 var email_reg = /^([a-zA-Z0-9]+[_|\_|\.]?)*[a-zA-Z0-9]+@([a-zA-Z0-9]+[_|\_|\.]?)*[a-zA-Z0-9]+\.[a-zA-Z]{2,3}$/;
                 if(!email_reg.test($("#email").val())) {
-                    $("#email").focus();
+                    id_name="#email";
                     msg_out("请输入有效的邮箱！","error");
                     msg_id=1;
                     return false;
                 }
                 if($("#passwd").val().length==0){
-                    $("#passwd").focus();
+                    id_name="#passwd";
                     msg_out("请输入密码","error");
                     msg_id=1;
                     return false;
@@ -149,7 +149,7 @@ require_once '../lib/config.php';
                 if($("#msg-error-p").eq(0)[0].innerHTML=="邮箱或者密码错误" 
                     || $("#msg-error-p").eq(0)[0].innerHTML=="邮箱或者密码错误，请重新输入！"){
                      if($("#passwd").val()==inpasswd && $("#email").val()==inemail){
-                        $("#passwd").focus();
+                        id_name="#passwd";
                         msg_out("邮箱或者密码错误，请重新输入！","error");
                         msg_id=1;
                         return false;
@@ -160,9 +160,16 @@ require_once '../lib/config.php';
                 }
             }
             function msg_out(msgout,msgcss){
+                // if($("#msg-error").css("display")=="block"){
+                //     msgcss="error";
+                // }
+                // if($("#msg-success").css("display")=="block"){
+                //     msgcss="success";
+                // }
                     $("#msg-"+msgcss).hide(10);
                     $("#msg-"+msgcss).show(100);
                     $("#msg-"+msgcss+"-p").html(msgout);
+                    $(id_name).focus();
             }
        
         $("html").keydown(function(event){
@@ -178,6 +185,7 @@ require_once '../lib/config.php';
         });
         $("#error-close").click(function(){
             $("#msg-error").hide(100);
+            $(id_name).focus();
         });
     })
 </script>

--- a/user/login.php
+++ b/user/login.php
@@ -52,12 +52,12 @@ require_once '../lib/config.php';
                     <button id="login" type="submit" class="btn btn-primary btn-block btn-flat">登录</button>
                 </div><!-- /.col -->
             </div>
-            <div id="msg-success" class="alert alert-info alert-dismissable" style="display: none;">
+            <div id="msg-success" class="alert alert-info alert-dismissable" style="border: 1px solid rgb(50, 163, 213); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -60px !important; position: fixed !important; display: none;">
                 <button type="button" class="close" id="ok-close" aria-hidden="true">&times;</button>
                 <h4><i class="icon fa fa-info"></i> 登录成功!</h4>
                 <p id="msg-success-p"></p>
             </div>
-            <div id="msg-error" class="alert alert-danger" style="display: none;">
+            <div id="msg-error" class="alert alert-danger" style="border: 1px solid rgb(255, 0, 0); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -60px !important; position: fixed !important; display: none;">
                 <button type="button" class="close" id="error-close" aria-hidden="true">&times;</button>
                 <h4><i class="icon fa fa-warning"></i> 出错了!</h4>
                 <p id="msg-error-p"></p>
@@ -122,33 +122,34 @@ require_once '../lib/config.php';
             {
                 var msg_id=0,msgcss="error";
                 if($("#email").val().length==0){
-                    msg_out("请输入邮箱","error");
                     $("#email").focus();
+                    msg_out("请输入邮箱","error");
                     msg_id=1;
                     return false;
                 }
                 var email_reg = /^([a-zA-Z0-9]+[_|\_|\.]?)*[a-zA-Z0-9]+@([a-zA-Z0-9]+[_|\_|\.]?)*[a-zA-Z0-9]+\.[a-zA-Z]{2,3}$/;
                 if(!email_reg.test($("#email").val())) {
-                    msg_out("请输入有效的邮箱！","error");
                     $("#email").focus();
+                    msg_out("请输入有效的邮箱！","error");
                     msg_id=1;
                     return false;
                 }
                 if($("#passwd").val().length==0){
-                    msg_out("请输入密码","error");
                     $("#passwd").focus();
+                    msg_out("请输入密码","error");
                     msg_id=1;
                     return false;
                 }
                 if($("#msg-success-p").eq(0)[0].innerHTML=="欢迎回来" 
-                    || $("#msg-success-p").eq(0)[0].innerHTML=="你已成功登录，如果页面不跳转，请刷新！"){
-                        msg_out("你已成功登录，如果页面不跳转，请刷新！","success");
+                    || $("#msg-success-p").eq(0)[0].innerHTML=="你已成功登录！"){
+                        msg_out("你已成功登录！","success");
                         msg_id=1;
-                         $("#msg-error-p").html("");
+                         $("#msg-error-p").html(null);
                 }
                 if($("#msg-error-p").eq(0)[0].innerHTML=="邮箱或者密码错误" 
                     || $("#msg-error-p").eq(0)[0].innerHTML=="邮箱或者密码错误，请重新输入！"){
                      if($("#passwd").val()==inpasswd && $("#email").val()==inemail){
+                        $("#passwd").focus();
                         msg_out("邮箱或者密码错误，请重新输入！","error");
                         msg_id=1;
                         return false;

--- a/user/login.php
+++ b/user/login.php
@@ -57,7 +57,7 @@ require_once '../lib/config.php';
                 <h4><i class="icon fa fa-info"></i> 登录成功!</h4>
                 <p id="msg-success-p"></p>
             </div>
-            <div id="msg-error" class="alert alert-warning alert-dismissable" style="display: none;">
+            <div id="msg-error" class="alert alert-danger" style="display: none;">
                 <button type="button" class="close" id="error-close" aria-hidden="true">&times;</button>
                 <h4><i class="icon fa fa-warning"></i> 出错了!</h4>
                 <p id="msg-error-p"></p>
@@ -82,11 +82,8 @@ require_once '../lib/config.php';
             increaseArea: '20%' // optional
         });
     });
-    // $("#msg-error").hide(100);
-    // $("#msg-success").hide(100);
 </script>
 <script>
-
     $(document).ready(function(){
         function login(){
             $.ajax({
@@ -100,7 +97,7 @@ require_once '../lib/config.php';
                 },
                 success:function(data){
                     if(data.ok){
-                        $("#msg-error").hide(100);
+                        $("#msg-error").hide(10);
                         $("#msg-success").show(100);
                         $("#msg-success-p").html(data.msg);
                         window.setTimeout("location.href='index.php'", 2000);
@@ -109,6 +106,7 @@ require_once '../lib/config.php';
                         $("#msg-error").show(100);
                         $("#msg-error-p").html(data.msg);
                     }
+                    
                 },
                 error:function(jqXHR){
                     $("#msg-error").hide(10);
@@ -116,14 +114,63 @@ require_once '../lib/config.php';
                     $("#msg-error-p").html("发生错误："+jqXHR.status);
                 }
             });
+            
+            inemail=$("#email").val();
+            inpasswd=$("#passwd").val();
         }
+        function logincheck()
+            {
+                var msg_id=0,msgcss="error";
+                if($("#email").val().length==0){
+                    msg_out("请输入邮箱","error");
+                    $("#email").focus();
+                    msg_id=1;
+                    return false;
+                }
+                var email_reg = /^([a-zA-Z0-9]+[_|\_|\.]?)*[a-zA-Z0-9]+@([a-zA-Z0-9]+[_|\_|\.]?)*[a-zA-Z0-9]+\.[a-zA-Z]{2,3}$/;
+                if(!email_reg.test($("#email").val())) {
+                    msg_out("请输入有效的邮箱！","error");
+                    $("#email").focus();
+                    msg_id=1;
+                    return false;
+                }
+                if($("#passwd").val().length==0){
+                    msg_out("请输入密码","error");
+                    $("#passwd").focus();
+                    msg_id=1;
+                    return false;
+                }
+                if($("#msg-success-p").eq(0)[0].innerHTML=="欢迎回来" 
+                    || $("#msg-success-p").eq(0)[0].innerHTML=="你已成功登录，如果页面不跳转，请刷新！"){
+                        msg_out("你已成功登录，如果页面不跳转，请刷新！","success");
+                        msg_id=1;
+                         $("#msg-error-p").html("");
+                }
+                if($("#msg-error-p").eq(0)[0].innerHTML=="邮箱或者密码错误" 
+                    || $("#msg-error-p").eq(0)[0].innerHTML=="邮箱或者密码错误，请重新输入！"){
+                     if($("#passwd").val()==inpasswd && $("#email").val()==inemail){
+                        msg_out("邮箱或者密码错误，请重新输入！","error");
+                        msg_id=1;
+                        return false;
+                    }
+                }
+                if(msg_id==0){
+                    login();
+                }
+            }
+            function msg_out(msgout,msgcss){
+                    $("#msg-"+msgcss).hide(10);
+                    $("#msg-"+msgcss).show(100);
+                    $("#msg-"+msgcss+"-p").html(msgout);
+            }
+       
         $("html").keydown(function(event){
             if(event.keyCode==13){
-                login();
+                logincheck();
             }
         });
         $("#login").click(function(){
-            login();
+            logincheck();
         });
          $("#ok-close").click(function(){
             $("#msg-success").hide(100);

--- a/user/register.php
+++ b/user/register.php
@@ -32,7 +32,7 @@ require_once '../lib/config.php';
         <p class="login-box-msg">注册，然后变成一只猫。</p>
 
             <div class="form-group has-feedback">
-                <input type="text" id="name" class="form-control" placeholder="用户名"/>
+                <input type="text" id="name" class="form-control" autofocus="autofocus" placeholder="用户名"/>
                 <span class="glyphicon glyphicon-user form-control-feedback"></span>
             </div>
             <div class="form-group has-feedback">
@@ -67,7 +67,7 @@ require_once '../lib/config.php';
                 <p id="msg-success-p"></p>
             </div>
     
-            <div id="msg-error" class="alert alert-danger" style="border: 1px solid rgb(255, 0, 0); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -148px !important; position: fixed !important; display: none;">
+            <div id="msg-error" class="alert alert-danger" title="点击关闭" style="border: 1px solid rgb(255, 0, 0); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -148px !important; position: fixed !important; display: none;">
                 <button type="button" class="close" id="error-close" aria-hidden="true">&times;</button>
                 <h4><i class="icon fa fa-warning"></i> 出错了!</h4>
                 <p id="msg-error-p"></p>
@@ -207,7 +207,6 @@ require_once '../lib/config.php';
                     $("#msg-"+msgcss).hide(10);
                     $("#msg-"+msgcss).show(100);
                     $("#msg-"+msgcss+"-p").html(msgout);
-                    $(id_name).focus();
             }
         $("html").keydown(function(event){
             if(event.keyCode==13){
@@ -220,7 +219,7 @@ require_once '../lib/config.php';
         $("#ok-close").click(function(){
             $("#msg-success").hide(100);
         });
-        $("#error-close").click(function(){
+        $("#msg-error").click(function(){
             $("#msg-error").hide(100);
             $(id_name).focus();
         });

--- a/user/register.php
+++ b/user/register.php
@@ -61,13 +61,13 @@ require_once '../lib/config.php';
                 <button type="submit" id="reg" class="btn btn-primary btn-block btn-flat">同意服务条款并提交注册</button>
             </div>
             
-            <div id="msg-success" class="alert alert-info alert-dismissable" style="display: none;">
+            <div id="msg-success" class="alert alert-info alert-dismissable" style="border: 1px solid rgb(50, 163, 213); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -60px !important; position: fixed !important; display: none;">
                 <button type="button" class="close" id="ok-close" aria-hidden="true">&times;</button>
                 <h4><i class="icon fa fa-info"></i> 成功!</h4>
                 <p id="msg-success-p"></p>
             </div>
     
-            <div id="msg-error" class="alert alert-danger" style="display: none;">
+            <div id="msg-error" class="alert alert-danger" style="border: 1px solid rgb(255, 0, 0); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -60px !important; position: fixed !important; display: none;">
                 <button type="button" class="close" id="error-close" aria-hidden="true">&times;</button>
                 <h4><i class="icon fa fa-warning"></i> 出错了!</h4>
                 <p id="msg-error-p"></p>
@@ -134,57 +134,57 @@ require_once '../lib/config.php';
         function registercheck(){
                 var msg_id=0;
                 if($("#name").val().length==0){
-                    msg_out("请输入昵称","error");
                     $("#name").focus();
+                    msg_out("请输入昵称","error");
                     msg_id=1;
                     return false;
                 }
                 if($("#email").val().length==0){
-                    msg_out("请输入邮箱","error");
                     $("#email").focus();
+                    msg_out("请输入邮箱","error");
                     msg_id=1;
                     return false;
                 }
                 var email_reg = /^([a-zA-Z0-9]+[_|\_|\.]?)*[a-zA-Z0-9]+@([a-zA-Z0-9]+[_|\_|\.]?)*[a-zA-Z0-9]+\.[a-zA-Z]{2,3}$/;
                 if(!email_reg.test($("#email").val())) {
-                    msg_out("请输入有效的邮箱！","error");
                     $("#email").focus();
+                    msg_out("请输入有效的邮箱！","error");
                     msg_id=1;
                     return false;
                 }
                 if($("#passwd").val().length==0){
-                    msg_out("请输入密码","error");
                     $("#passwd").focus();
+                    msg_out("请输入密码","error");
                     msg_id=1;
                     return false;
                 }
                 if($("#repasswd").val().length==0){
-                    msg_out("请输入重复密码","error");
                     $("#repasswd").focus();
+                    msg_out("请输入重复密码","error");
                     msg_id=1;
                     return false;
                 }
                 if($("#passwd").val() != $("#repasswd").val()){
-                    msg_out("两次密码不一样，请重新输入！","error");
                     $("#repasswd").focus();
+                    msg_out("两次密码不一样，请重新输入！","error");
                     msg_id=1;
                     return false;
                 }
                 if($("#code").val().length==0){
-                    msg_out("请输入邀请码","error");
                     $("#code").focus();
+                    msg_out("请输入邀请码","error");
                     msg_id=1;
                     return false;
                 }
-                if($("#msg-success-p").eq(0)[0].innerHTML=="注册成功"
-                   || $("#msg-success-p").eq(0)[0].innerHTML=="你已注册成功，如果页面不跳转，请刷新！"){
-                        msg_out("你已注册成功，如果页面不跳转，请刷新！","success");
+                if($("#msg-success-p").eq(0)[0].innerHTML=="注册成功"){
+                        msg_out("注册成功！","success");
                         msg_id=1;
-                        $("#msg-error-p").html("");
+                        $("#msg-error-p").html(null);
                 }
                 if($("#msg-error-p").eq(0)[0].innerHTML=="邀请码无效" 
                    || $("#msg-error-p").eq(0)[0].innerHTML=="邀请码无效，请重新输入！"){
                      if($("#code").val()==incode){
+                        $("#code").focus();
                         msg_out("邀请码无效，请重新输入！","error");
                         msg_id=1;
                         return false;

--- a/user/register.php
+++ b/user/register.php
@@ -67,7 +67,7 @@ require_once '../lib/config.php';
                 <p id="msg-success-p"></p>
             </div>
     
-            <div id="msg-error" class="alert alert-warning alert-dismissable" style="display: none;">
+            <div id="msg-error" class="alert alert-danger" style="display: none;">
                 <button type="button" class="close" id="error-close" aria-hidden="true">&times;</button>
                 <h4><i class="icon fa fa-warning"></i> 出错了!</h4>
                 <p id="msg-error-p"></p>
@@ -128,14 +128,84 @@ require_once '../lib/config.php';
                     $("#msg-error-p").html("发生错误："+jqXHR.status);
                 }
             });
+            
+            incode=$("#code").val();
         }
+        function registercheck(){
+                var msg_id=0;
+                if($("#name").val().length==0){
+                    msg_out("请输入昵称","error");
+                    $("#name").focus();
+                    msg_id=1;
+                    return false;
+                }
+                if($("#email").val().length==0){
+                    msg_out("请输入邮箱","error");
+                    $("#email").focus();
+                    msg_id=1;
+                    return false;
+                }
+                var email_reg = /^([a-zA-Z0-9]+[_|\_|\.]?)*[a-zA-Z0-9]+@([a-zA-Z0-9]+[_|\_|\.]?)*[a-zA-Z0-9]+\.[a-zA-Z]{2,3}$/;
+                if(!email_reg.test($("#email").val())) {
+                    msg_out("请输入有效的邮箱！","error");
+                    $("#email").focus();
+                    msg_id=1;
+                    return false;
+                }
+                if($("#passwd").val().length==0){
+                    msg_out("请输入密码","error");
+                    $("#passwd").focus();
+                    msg_id=1;
+                    return false;
+                }
+                if($("#repasswd").val().length==0){
+                    msg_out("请输入重复密码","error");
+                    $("#repasswd").focus();
+                    msg_id=1;
+                    return false;
+                }
+                if($("#passwd").val() != $("#repasswd").val()){
+                    msg_out("两次密码不一样，请重新输入！","error");
+                    $("#repasswd").focus();
+                    msg_id=1;
+                    return false;
+                }
+                if($("#code").val().length==0){
+                    msg_out("请输入邀请码","error");
+                    $("#code").focus();
+                    msg_id=1;
+                    return false;
+                }
+                if($("#msg-success-p").eq(0)[0].innerHTML=="注册成功"
+                   || $("#msg-success-p").eq(0)[0].innerHTML=="你已注册成功，如果页面不跳转，请刷新！"){
+                        msg_out("你已注册成功，如果页面不跳转，请刷新！","success");
+                        msg_id=1;
+                        $("#msg-error-p").html("");
+                }
+                if($("#msg-error-p").eq(0)[0].innerHTML=="邀请码无效" 
+                   || $("#msg-error-p").eq(0)[0].innerHTML=="邀请码无效，请重新输入！"){
+                     if($("#code").val()==incode){
+                        msg_out("邀请码无效，请重新输入！","error");
+                        msg_id=1;
+                        return false;
+                    }
+                }
+                if(msg_id==0){
+                    register();
+                }
+            }
+            function msg_out(msgout,msgcss){
+                    $("#msg-"+msgcss).hide(10);
+                    $("#msg-"+msgcss).show(100);
+                    $("#msg-"+msgcss+"-p").html(msgout);
+            }
         $("html").keydown(function(event){
             if(event.keyCode==13){
-                register();
+                registercheck();
             }
         });
         $("#reg").click(function(){
-            register();
+            registercheck();
         });
         $("#ok-close").click(function(){
             $("#msg-success").hide(100);

--- a/user/register.php
+++ b/user/register.php
@@ -32,7 +32,7 @@ require_once '../lib/config.php';
         <p class="login-box-msg">注册，然后变成一只猫。</p>
 
             <div class="form-group has-feedback">
-                <input type="text" id="name" class="form-control" placeholder="昵称"/>
+                <input type="text" id="name" class="form-control" placeholder="用户名"/>
                 <span class="glyphicon glyphicon-user form-control-feedback"></span>
             </div>
             <div class="form-group has-feedback">
@@ -61,13 +61,13 @@ require_once '../lib/config.php';
                 <button type="submit" id="reg" class="btn btn-primary btn-block btn-flat">同意服务条款并提交注册</button>
             </div>
             
-            <div id="msg-success" class="alert alert-info alert-dismissable" style="border: 1px solid rgb(50, 163, 213); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -60px !important; position: fixed !important; display: none;">
+            <div id="msg-success" class="alert alert-info alert-dismissable" style="border: 1px solid rgb(50, 163, 213); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -148px !important; position: fixed !important; display: none;">
                 <button type="button" class="close" id="ok-close" aria-hidden="true">&times;</button>
                 <h4><i class="icon fa fa-info"></i> 成功!</h4>
                 <p id="msg-success-p"></p>
             </div>
     
-            <div id="msg-error" class="alert alert-danger" style="border: 1px solid rgb(255, 0, 0); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -60px !important; position: fixed !important; display: none;">
+            <div id="msg-error" class="alert alert-danger" style="border: 1px solid rgb(255, 0, 0); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -148px !important; position: fixed !important; display: none;">
                 <button type="button" class="close" id="error-close" aria-hidden="true">&times;</button>
                 <h4><i class="icon fa fa-warning"></i> 出错了!</h4>
                 <p id="msg-error-p"></p>
@@ -90,9 +90,6 @@ require_once '../lib/config.php';
             radioClass: 'iradio_square-blue',
             increaseArea: '20%' // optional
         });
-        // $("#msg-error").hide(100);
-        // $("#msg-success").hide(100);
-
     });
 </script>
 <script>
@@ -135,7 +132,13 @@ require_once '../lib/config.php';
                 var msg_id=0;
                 if($("#name").val().length==0){
                     id_name="#name";
-                    msg_out("请输入昵称","error");
+                    msg_out("请输入用户名","error");
+                    msg_id=1;
+                    return false;
+                }
+                if(($("#name").val()).length<7){
+                    id_name="#name";
+                    msg_out("用户名太短，长度为7个字符。","error");
                     msg_id=1;
                     return false;
                 }
@@ -155,6 +158,12 @@ require_once '../lib/config.php';
                 if($("#passwd").val().length==0){
                     id_name="#passwd";
                     msg_out("请输入密码","error");
+                    msg_id=1;
+                    return false;
+                }
+                if(($("#passwd").val()).length<8){
+                    id_name="#passwd";
+                    msg_out("密码太短，长度为8位以上。","error");
                     msg_id=1;
                     return false;
                 }

--- a/user/register.php
+++ b/user/register.php
@@ -212,6 +212,9 @@ require_once '../lib/config.php';
             if(event.keyCode==13){
                 registercheck();
             }
+            if(event.keyCode==27){
+                error_close();
+            }
         });
         $("#reg").click(function(){
             registercheck();
@@ -219,10 +222,18 @@ require_once '../lib/config.php';
         $("#ok-close").click(function(){
             $("#msg-success").hide(100);
         });
-        $("#msg-error").click(function(){
-            $("#msg-error").hide(100);
-            $(id_name).focus();
+       $("#msg-error").click(function(){
+            error_close();
         });
+        function error_close(){
+            if($("#msg-error").css('display')=="block"){
+                $("#msg-error").hide(100);
+                $(id_name).focus();
+                if(id_name=="#email"){
+                    $(id_name).select();
+                }
+            }
+        }
     })
 </script>
 </body>

--- a/user/register.php
+++ b/user/register.php
@@ -134,57 +134,57 @@ require_once '../lib/config.php';
         function registercheck(){
                 var msg_id=0;
                 if($("#name").val().length==0){
-                    $("#name").focus();
+                    id_name="#name";
                     msg_out("请输入昵称","error");
                     msg_id=1;
                     return false;
                 }
                 if($("#email").val().length==0){
-                    $("#email").focus();
+                    id_name="#email";
                     msg_out("请输入邮箱","error");
                     msg_id=1;
                     return false;
                 }
                 var email_reg = /^([a-zA-Z0-9]+[_|\_|\.]?)*[a-zA-Z0-9]+@([a-zA-Z0-9]+[_|\_|\.]?)*[a-zA-Z0-9]+\.[a-zA-Z]{2,3}$/;
                 if(!email_reg.test($("#email").val())) {
-                    $("#email").focus();
+                    id_name="#email";
                     msg_out("请输入有效的邮箱！","error");
                     msg_id=1;
                     return false;
                 }
                 if($("#passwd").val().length==0){
-                    $("#passwd").focus();
+                    id_name="#passwd";
                     msg_out("请输入密码","error");
                     msg_id=1;
                     return false;
                 }
                 if($("#repasswd").val().length==0){
-                    $("#repasswd").focus();
+                    id_name="#repasswd";
                     msg_out("请输入重复密码","error");
                     msg_id=1;
                     return false;
                 }
                 if($("#passwd").val() != $("#repasswd").val()){
-                    $("#repasswd").focus();
+                    id_name="#repasswd";
                     msg_out("两次密码不一样，请重新输入！","error");
                     msg_id=1;
                     return false;
                 }
                 if($("#code").val().length==0){
-                    $("#code").focus();
+                    id_name="#code";
                     msg_out("请输入邀请码","error");
                     msg_id=1;
                     return false;
                 }
                 if($("#msg-success-p").eq(0)[0].innerHTML=="注册成功"){
-                        msg_out("注册成功！","success");
+                        msg_out("注册成功","success");
                         msg_id=1;
                         $("#msg-error-p").html(null);
                 }
                 if($("#msg-error-p").eq(0)[0].innerHTML=="邀请码无效" 
                    || $("#msg-error-p").eq(0)[0].innerHTML=="邀请码无效，请重新输入！"){
                      if($("#code").val()==incode){
-                        $("#code").focus();
+                        id_name="#code";
                         msg_out("邀请码无效，请重新输入！","error");
                         msg_id=1;
                         return false;
@@ -198,6 +198,7 @@ require_once '../lib/config.php';
                     $("#msg-"+msgcss).hide(10);
                     $("#msg-"+msgcss).show(100);
                     $("#msg-"+msgcss+"-p").html(msgout);
+                    $(id_name).focus();
             }
         $("html").keydown(function(event){
             if(event.keyCode==13){
@@ -212,6 +213,7 @@ require_once '../lib/config.php';
         });
         $("#error-close").click(function(){
             $("#msg-error").hide(100);
+            $(id_name).focus();
         });
     })
 </script>

--- a/user/resetpwd.php
+++ b/user/resetpwd.php
@@ -110,14 +110,14 @@ $uid  = $_GET['uid'];
         function resetcheck(){
                     var msg_id=0;
                     if($("#email").val().length==0){
-                        $("#email").focus();
+                        id_name="#email";
                         msg_out("请输入邮箱","error");
                         msg_id=1;
                         return false;
                     }
                     var email_reg = /^([a-zA-Z0-9]+[_|\_|\.]?)*[a-zA-Z0-9]+@([a-zA-Z0-9]+[_|\_|\.]?)*[a-zA-Z0-9]+\.[a-zA-Z]{2,3}$/;
                     if(!email_reg.test($("#email").val())) {
-                        $("#email").focus();
+                        id_name="#email";
                         msg_out("请输入有效的邮箱！","error");
                         msg_id=1;
                         return false;
@@ -130,7 +130,7 @@ $uid  = $_GET['uid'];
                     if($("#msg-error-p").eq(0)[0].innerHTML=="邮箱不存在" 
                     || $("#msg-error-p").eq(0)[0].innerHTML=="邮箱不存在，请重新输入！"){
                          if($("#email").val()==inpemail){
-                            $("#email").focus();
+                            id_name="#email";
                             msg_out("邮箱不存在，请重新输入！","error");
                             msg_id=1;
                             return false;
@@ -144,6 +144,7 @@ $uid  = $_GET['uid'];
                     $("#msg-"+msgcss).hide(10);
                     $("#msg-"+msgcss).show(100);
                     $("#msg-"+msgcss+"-p").html(msgout);
+                    $(id_name).focus();
         }
         $("html").keydown(function(event){
             if(event.keyCode==13){
@@ -158,6 +159,7 @@ $uid  = $_GET['uid'];
         });
         $("#error-close").click(function(){
             $("#msg-error").hide(100);
+            $(id_name).focus();
         });
     })
 </script>

--- a/user/resetpwd.php
+++ b/user/resetpwd.php
@@ -149,6 +149,9 @@ $uid  = $_GET['uid'];
             if(event.keyCode==13){
                 resetcheck();
             }
+            if(event.keyCode==27){
+                error_close();
+            }
         });
         $("#reset").click(function(){
             resetcheck();
@@ -157,9 +160,17 @@ $uid  = $_GET['uid'];
             $("#msg-success").hide(100);
         });
         $("#msg-error").click(function(){
-            $("#msg-error").hide(100);
-            $(id_name).focus();
+            error_close();
         });
+        function error_close(){
+            if($("#msg-error").css('display')=="block"){
+                $("#msg-error").hide(100);
+                $(id_name).focus();
+                if(id_name=="#email"){
+                    $(id_name).select();
+                }
+            }
+        }
     })
 </script>
 

--- a/user/resetpwd.php
+++ b/user/resetpwd.php
@@ -36,7 +36,7 @@ $uid  = $_GET['uid'];
             <input type="hidden" id="uid" name="uid" class="form-control" value="<?php echo $uid;?>" required autofocus>
             
             <div class="form-group has-feedback">
-                <input id="email" name="Email" type="text" class="form-control" placeholder="邮箱"/>
+                <input id="email" name="Email" type="text" class="form-control" autofocus="autofocus" placeholder="邮箱"/>
                 <span  class="glyphicon glyphicon-envelope form-control-feedback"></span>
             </div>
 
@@ -50,7 +50,7 @@ $uid  = $_GET['uid'];
                 <p id="msg-success-p"></p>
             </div>
     
-            <div id="msg-error" class="alert alert-danger" style="border: 1px solid rgb(255, 0, 0); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -60px !important; position: fixed !important; display: none;">
+            <div id="msg-error" class="alert alert-danger" title="点击关闭" style="border: 1px solid rgb(255, 0, 0); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -60px !important; position: fixed !important; display: none;">
                 <button type="button" class="close" id="error-close" aria-hidden="true">&times;</button>
                 <h4><i class="icon fa fa-warning"></i> 出错了!</h4>
                 <p id="msg-error-p"></p>
@@ -144,7 +144,6 @@ $uid  = $_GET['uid'];
                     $("#msg-"+msgcss).hide(10);
                     $("#msg-"+msgcss).show(100);
                     $("#msg-"+msgcss+"-p").html(msgout);
-                    $(id_name).focus();
         }
         $("html").keydown(function(event){
             if(event.keyCode==13){
@@ -157,7 +156,7 @@ $uid  = $_GET['uid'];
         $("#ok-close").click(function(){
             $("#msg-success").hide(100);
         });
-        $("#error-close").click(function(){
+        $("#msg-error").click(function(){
             $("#msg-error").hide(100);
             $(id_name).focus();
         });

--- a/user/resetpwd.php
+++ b/user/resetpwd.php
@@ -44,13 +44,13 @@ $uid  = $_GET['uid'];
                 <button type="submit" id="reset" class="btn btn-primary btn-block btn-flat">重置</button>
             </div>
     
-            <div id="msg-success" class="alert alert-info alert-dismissable" style="display: none;">
+            <div id="msg-success" class="alert alert-info alert-dismissable" style="border: 1px solid rgb(50, 163, 213); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -60px !important; position: fixed !important; display: none;">
                 <button type="button" class="close" id="ok-close" aria-hidden="true">&times;</button>
                 <h4><i class="icon fa fa-info"></i> 成功!</h4>
                 <p id="msg-success-p"></p>
             </div>
     
-            <div id="msg-error" class="alert alert-danger" style="display: none;">
+            <div id="msg-error" class="alert alert-danger" style="border: 1px solid rgb(255, 0, 0); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -60px !important; position: fixed !important; display: none;">
                 <button type="button" class="close" id="error-close" aria-hidden="true">&times;</button>
                 <h4><i class="icon fa fa-warning"></i> 出错了!</h4>
                 <p id="msg-error-p"></p>
@@ -110,26 +110,27 @@ $uid  = $_GET['uid'];
         function resetcheck(){
                     var msg_id=0;
                     if($("#email").val().length==0){
-                        msg_out("请输入邮箱","error");
                         $("#email").focus();
+                        msg_out("请输入邮箱","error");
                         msg_id=1;
                         return false;
                     }
                     var email_reg = /^([a-zA-Z0-9]+[_|\_|\.]?)*[a-zA-Z0-9]+@([a-zA-Z0-9]+[_|\_|\.]?)*[a-zA-Z0-9]+\.[a-zA-Z]{2,3}$/;
                     if(!email_reg.test($("#email").val())) {
-                        msg_out("请输入有效的邮箱！","error");
                         $("#email").focus();
+                        msg_out("请输入有效的邮箱！","error");
                         msg_id=1;
                         return false;
                     }
                     if($("#msg-success-p").eq(0)[0].innerHTML=="已经发送到邮箱"){
                             msg_out("已经发送到邮箱","success");
                             msg_id=1;
-                            $("#msg-error-p").html("");
+                            $("#msg-error-p").html(null);
                      }
                     if($("#msg-error-p").eq(0)[0].innerHTML=="邮箱不存在" 
                     || $("#msg-error-p").eq(0)[0].innerHTML=="邮箱不存在，请重新输入！"){
                          if($("#email").val()==inpemail){
+                            $("#email").focus();
                             msg_out("邮箱不存在，请重新输入！","error");
                             msg_id=1;
                             return false;

--- a/user/resetpwd.php
+++ b/user/resetpwd.php
@@ -34,7 +34,7 @@ $uid  = $_GET['uid'];
 
             <input type="hidden" id="code" name="code" class="form-control" value="<?php echo $code;?>" required autofocus>
             <input type="hidden" id="uid" name="uid" class="form-control" value="<?php echo $uid;?>" required autofocus>
-
+            
             <div class="form-group has-feedback">
                 <input id="email" name="Email" type="text" class="form-control" placeholder="Email"/>
                 <span  class="glyphicon glyphicon-envelope form-control-feedback"></span>
@@ -50,7 +50,7 @@ $uid  = $_GET['uid'];
                 <p id="msg-success-p"></p>
             </div>
     
-            <div id="msg-error" class="alert alert-warning alert-dismissable" style="display: none;">
+            <div id="msg-error" class="alert alert-danger" style="display: none;">
                 <button type="button" class="close" id="error-close" aria-hidden="true">&times;</button>
                 <h4><i class="icon fa fa-warning"></i> 出错了!</h4>
                 <p id="msg-error-p"></p>
@@ -88,7 +88,7 @@ $uid  = $_GET['uid'];
                 dataType:"json",
                 success:function(data){
                     if(data.ok){
-                        $("#msg-error").hide(100);
+                        $("#msg-error").hide(10);
                         $("#msg-success").show(100);
                         $("#msg-success-p").html(data.msg);
                         window.setTimeout("location.href='index.php'", 2000);
@@ -104,14 +104,53 @@ $uid  = $_GET['uid'];
                     $("#msg-error-p").html("发生错误："+jqXHR.status);
                 }
             });
-          }
+            
+            inpemail=$("#email").val();
+        }
+        function resetcheck(){
+                    var msg_id=0;
+                    if($("#email").val().length==0){
+                        msg_out("请输入邮箱","error");
+                        $("#email").focus();
+                        msg_id=1;
+                        return false;
+                    }
+                    var email_reg = /^([a-zA-Z0-9]+[_|\_|\.]?)*[a-zA-Z0-9]+@([a-zA-Z0-9]+[_|\_|\.]?)*[a-zA-Z0-9]+\.[a-zA-Z]{2,3}$/;
+                    if(!email_reg.test($("#email").val())) {
+                        msg_out("请输入有效的邮箱！","error");
+                        $("#email").focus();
+                        msg_id=1;
+                        return false;
+                    }
+                    if($("#msg-success-p").eq(0)[0].innerHTML=="已经发送到邮箱"){
+                            msg_out("已经发送到邮箱","success");
+                            msg_id=1;
+                            $("#msg-error-p").html("");
+                     }
+                    if($("#msg-error-p").eq(0)[0].innerHTML=="邮箱不存在" 
+                    || $("#msg-error-p").eq(0)[0].innerHTML=="邮箱不存在，请重新输入！"){
+                         if($("#email").val()==inpemail){
+                            msg_out("邮箱不存在，请重新输入！","error");
+                            msg_id=1;
+                            return false;
+                            }
+                    }
+                    if(msg_id==0){ 
+                            reset();
+                    }
+        }
+        function msg_out(msgout,msgcss){
+                    $("#msg-"+msgcss).hide(10);
+                    $("#msg-"+msgcss).show(100);
+                    $("#msg-"+msgcss+"-p").html(msgout);
+        }
         $("html").keydown(function(event){
             if(event.keyCode==13){
-                reset();
+                resetcheck();
             }
         });
         $("#reset").click(function(){
-            reset();
+            resetcheck();
         });
         $("#ok-close").click(function(){
             $("#msg-success").hide(100);

--- a/user/resetpwd.php
+++ b/user/resetpwd.php
@@ -36,7 +36,7 @@ $uid  = $_GET['uid'];
             <input type="hidden" id="uid" name="uid" class="form-control" value="<?php echo $uid;?>" required autofocus>
             
             <div class="form-group has-feedback">
-                <input id="email" name="Email" type="text" class="form-control" placeholder="Email"/>
+                <input id="email" name="Email" type="text" class="form-control" placeholder="邮箱"/>
                 <span  class="glyphicon glyphicon-envelope form-control-feedback"></span>
             </div>
 

--- a/user/resetpwd_do.php
+++ b/user/resetpwd_do.php
@@ -147,6 +147,9 @@ $uid  = $_GET['uid'];
             if(event.keyCode==13){
                 resetcheck();
             }
+            if(event.keyCode==27){
+                error_close();
+            }
         });
         $("#reset").click(function(){
             resetcheck();
@@ -155,9 +158,17 @@ $uid  = $_GET['uid'];
             $("#msg-success").hide(100);
         });
         $("#msg-error").click(function(){
-            $("#msg-error").hide(100);
-            $(id_name).focus();
+            error_close();
         });
+        function error_close(){
+            if($("#msg-error").css('display')=="block"){
+                $("#msg-error").hide(100);
+                $(id_name).focus();
+                if(id_name=="#email"){
+                    $(id_name).select();
+                }
+            }
+        }
     })
 </script>
 

--- a/user/resetpwd_do.php
+++ b/user/resetpwd_do.php
@@ -44,13 +44,13 @@ $uid  = $_GET['uid'];
             <button type="submit" id="reset" class="btn btn-primary btn-block btn-flat">确认重置</button>
         </div>
         
-        <div id="msg-success" class="alert alert-info alert-dismissable" style="display: none;">
+        <div id="msg-success" class="alert alert-info alert-dismissable" style="border: 1px solid rgb(50, 163, 213); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -60px !important; position: fixed !important; display: none;">
             <button type="button" class="close" id="ok-close" aria-hidden="true">&times;</button>
             <h4><i class="icon fa fa-info"></i> 成功!</h4>
             <p id="msg-success-p"></p>
         </div>
 
-        <div id="msg-error" class="alert alert-danger" style="display: none;">
+        <div id="msg-error" class="alert alert-danger" style="border: 1px solid rgb(255, 0, 0); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -60px !important; position: fixed !important; display: none;">
             <button type="button" class="close" id="error-close" aria-hidden="true">&times;</button>
             <h4><i class="icon fa fa-warning"></i> 出错了!</h4>
             <p id="msg-error-p"></p>
@@ -108,26 +108,27 @@ $uid  = $_GET['uid'];
         function resetcheck(){
                     var msg_id=0;
                     if($("#email").val().length==0){
-                        msg_out("请输入邮箱","error");
                         $("#email").focus();
+                        msg_out("请输入邮箱","error");
                         msg_id=1;
                         return false;
                     }
                     var email_reg = /^([a-zA-Z0-9]+[_|\_|\.]?)*[a-zA-Z0-9]+@([a-zA-Z0-9]+[_|\_|\.]?)*[a-zA-Z0-9]+\.[a-zA-Z]{2,3}$/;
                     if(!email_reg.test($("#email").val())) {
-                        msg_out("请输入有效的邮箱！","error");
                         $("#email").focus();
+                        msg_out("请输入有效的邮箱！","error");
                         msg_id=1;
                         return false;
                     }
                     if($("#msg-success-p").eq(0)[0].innerHTML=="已经发送到邮箱"){
                             msg_out("已经发送到邮箱","success");
                             msg_id=1;
-                            $("#msg-error-p").html("");
+                            $("#msg-error-p").html(null);
                      }
                     if($("#msg-error-p").eq(0)[0].innerHTML=="邮箱错误" 
                     || $("#msg-error-p").eq(0)[0].innerHTML=="邮箱错误，请重新输入！"){
                          if($("#email").val()==inpemail){
+                            $("#email").focus();
                             msg_out("邮箱错误，请重新输入！","error");
                             msg_id=1;
                             return false;

--- a/user/resetpwd_do.php
+++ b/user/resetpwd_do.php
@@ -50,7 +50,7 @@ $uid  = $_GET['uid'];
             <p id="msg-success-p"></p>
         </div>
 
-        <div id="msg-error" class="alert alert-warning alert-dismissable" style="display: none;">
+        <div id="msg-error" class="alert alert-danger" style="display: none;">
             <button type="button" class="close" id="error-close" aria-hidden="true">&times;</button>
             <h4><i class="icon fa fa-warning"></i> 出错了!</h4>
             <p id="msg-error-p"></p>
@@ -102,14 +102,53 @@ $uid  = $_GET['uid'];
                     $("#msg-error-p").html("发生错误："+jqXHR.status);
                 }
             });
+            
+            inpemail=$("#email").val();
+        }
+        function resetcheck(){
+                    var msg_id=0;
+                    if($("#email").val().length==0){
+                        msg_out("请输入邮箱","error");
+                        $("#email").focus();
+                        msg_id=1;
+                        return false;
+                    }
+                    var email_reg = /^([a-zA-Z0-9]+[_|\_|\.]?)*[a-zA-Z0-9]+@([a-zA-Z0-9]+[_|\_|\.]?)*[a-zA-Z0-9]+\.[a-zA-Z]{2,3}$/;
+                    if(!email_reg.test($("#email").val())) {
+                        msg_out("请输入有效的邮箱！","error");
+                        $("#email").focus();
+                        msg_id=1;
+                        return false;
+                    }
+                    if($("#msg-success-p").eq(0)[0].innerHTML=="已经发送到邮箱"){
+                            msg_out("已经发送到邮箱","success");
+                            msg_id=1;
+                            $("#msg-error-p").html("");
+                     }
+                    if($("#msg-error-p").eq(0)[0].innerHTML=="邮箱错误" 
+                    || $("#msg-error-p").eq(0)[0].innerHTML=="邮箱错误，请重新输入！"){
+                         if($("#email").val()==inpemail){
+                            msg_out("邮箱错误，请重新输入！","error");
+                            msg_id=1;
+                            return false;
+                            }
+                    }
+                    if(msg_id==0){ 
+                            reset();
+                    }
+        }
+        function msg_out(msgout,msgcss){
+                    $("#msg-"+msgcss).hide(10);
+                    $("#msg-"+msgcss).show(100);
+                    $("#msg-"+msgcss+"-p").html(msgout);
         }
         $("html").keydown(function(event){
             if(event.keyCode==13){
-                reset();
+                resetcheck();
             }
         });
         $("#reset").click(function(){
-            reset();
+            resetcheck();
         });
         $("#ok-close").click(function(){
             $("#msg-success").hide(100);

--- a/user/resetpwd_do.php
+++ b/user/resetpwd_do.php
@@ -108,27 +108,27 @@ $uid  = $_GET['uid'];
         function resetcheck(){
                     var msg_id=0;
                     if($("#email").val().length==0){
-                        $("#email").focus();
+                        id_name="#email";
                         msg_out("请输入邮箱","error");
                         msg_id=1;
                         return false;
                     }
                     var email_reg = /^([a-zA-Z0-9]+[_|\_|\.]?)*[a-zA-Z0-9]+@([a-zA-Z0-9]+[_|\_|\.]?)*[a-zA-Z0-9]+\.[a-zA-Z]{2,3}$/;
                     if(!email_reg.test($("#email").val())) {
-                        $("#email").focus();
+                        id_name="#email";
                         msg_out("请输入有效的邮箱！","error");
                         msg_id=1;
                         return false;
                     }
                     if($("#msg-success-p").eq(0)[0].innerHTML=="已经发送到邮箱"){
-                            msg_out("已经发送到邮箱","success");
+                            msg_out("已经发送到邮箱！","success");
                             msg_id=1;
                             $("#msg-error-p").html(null);
                      }
                     if($("#msg-error-p").eq(0)[0].innerHTML=="邮箱错误" 
                     || $("#msg-error-p").eq(0)[0].innerHTML=="邮箱错误，请重新输入！"){
                          if($("#email").val()==inpemail){
-                            $("#email").focus();
+                            id_name="#email";
                             msg_out("邮箱错误，请重新输入！","error");
                             msg_id=1;
                             return false;
@@ -142,6 +142,7 @@ $uid  = $_GET['uid'];
                     $("#msg-"+msgcss).hide(10);
                     $("#msg-"+msgcss).show(100);
                     $("#msg-"+msgcss+"-p").html(msgout);
+                    $(id_name).focus();
         }
         $("html").keydown(function(event){
             if(event.keyCode==13){
@@ -156,6 +157,7 @@ $uid  = $_GET['uid'];
         });
         $("#error-close").click(function(){
             $("#msg-error").hide(100);
+            $(id_name).focus();
         });
     })
 </script>

--- a/user/resetpwd_do.php
+++ b/user/resetpwd_do.php
@@ -36,7 +36,7 @@ $uid  = $_GET['uid'];
         <input type="hidden" id="uid" name="uid" class="form-control" value="<?php echo $uid;?>" >
 
         <div class="form-group has-feedback">
-            <input id="email" name="Email" type="text" class="form-control" placeholder="邮箱"/>
+            <input id="email" name="Email" type="text" class="form-control" autofocus="autofocus" placeholder="邮箱"/>
             <span  class="glyphicon glyphicon-envelope form-control-feedback"></span>
         </div>
 
@@ -50,7 +50,7 @@ $uid  = $_GET['uid'];
             <p id="msg-success-p"></p>
         </div>
 
-        <div id="msg-error" class="alert alert-danger" style="border: 1px solid rgb(255, 0, 0); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -60px !important; position: fixed !important; display: none;">
+        <div id="msg-error" class="alert alert-danger" title="点击关闭" style="border: 1px solid rgb(255, 0, 0); text-align: center; z-index: 999; width: 300px; left: 50%; margin-left: -150px !important; margin-top: -60px !important; position: fixed !important; display: none;">
             <button type="button" class="close" id="error-close" aria-hidden="true">&times;</button>
             <h4><i class="icon fa fa-warning"></i> 出错了!</h4>
             <p id="msg-error-p"></p>
@@ -142,7 +142,6 @@ $uid  = $_GET['uid'];
                     $("#msg-"+msgcss).hide(10);
                     $("#msg-"+msgcss).show(100);
                     $("#msg-"+msgcss+"-p").html(msgout);
-                    $(id_name).focus();
         }
         $("html").keydown(function(event){
             if(event.keyCode==13){
@@ -155,7 +154,7 @@ $uid  = $_GET['uid'];
         $("#ok-close").click(function(){
             $("#msg-success").hide(100);
         });
-        $("#error-close").click(function(){
+        $("#msg-error").click(function(){
             $("#msg-error").hide(100);
             $(id_name).focus();
         });

--- a/user/resetpwd_do.php
+++ b/user/resetpwd_do.php
@@ -36,7 +36,7 @@ $uid  = $_GET['uid'];
         <input type="hidden" id="uid" name="uid" class="form-control" value="<?php echo $uid;?>" >
 
         <div class="form-group has-feedback">
-            <input id="email" name="Email" type="text" class="form-control" placeholder="Email"/>
+            <input id="email" name="Email" type="text" class="form-control" placeholder="邮箱"/>
             <span  class="glyphicon glyphicon-envelope form-control-feedback"></span>
         </div>
 
@@ -121,7 +121,7 @@ $uid  = $_GET['uid'];
                         return false;
                     }
                     if($("#msg-success-p").eq(0)[0].innerHTML=="已经发送到邮箱"){
-                            msg_out("已经发送到邮箱！","success");
+                            msg_out("已经发送到邮箱","success");
                             msg_id=1;
                             $("#msg-error-p").html(null);
                      }


### PR DESCRIPTION
如果你的提示文字已修改，请在新文件对应的提示文字修改，以防本地验证失效！
还针对按回车不放的用户优化，禁止重复提交，预防多余不必要的请求连接。
修复已知问题，改用浮动层，不会再因为弹出提示而改变页面排版。

![20150520155239](https://cloud.githubusercontent.com/assets/11162054/7721879/f294f01c-ff0d-11e4-933f-7fbf8d3a23f2.png)

![20150520160416](https://cloud.githubusercontent.com/assets/11162054/7721878/f2925a64-ff0d-11e4-96ad-7d1dd5232423.png)

![20150520163228](https://cloud.githubusercontent.com/assets/11162054/7721964/9b15854e-ff0e-11e4-85f5-fab5d43c5645.png)

![20150520163258](https://cloud.githubusercontent.com/assets/11162054/7721989/b0bac44a-ff0e-11e4-8380-a6ba47eff3aa.png)

```js
//欢迎回来 是服务器返回的提示文字，如果你的已经修改，请在新文件对应的提示文字修改，以防本地验证失效！
if($("#msg-success-p").eq(0)[0].innerHTML=="欢迎回来" 
                    || $("#msg-success-p").eq(0)[0].innerHTML=="你已成功登录"){
                      // 这里第一个是提示文字，如果要改，上面判断的也要一起改。
                      //第二个是显示的样式，分两个： 出错了（error）成功（success ）
                        msg_out("你已成功登录","success");
                        //如果 msg_id=1 不执行（提）登（交）录
                        msg_id=0;
                         $("#msg-error-p").html(null);
                }
                if($("#msg-error-p").eq(0)[0].innerHTML=="邮箱或者密码错误" 
                    || $("#msg-error-p").eq(0)[0].innerHTML=="邮箱或者密码错误，请重新输入！"){
                     if($("#passwd").val()==inpasswd && $("#email").val()==inemail){
                        msg_out("邮箱或者密码错误，请重新输入！","error");
                        msg_id=1;
                        return false;
                    }
                }
```