### PR TITLE
加入防签到系统平台，$site_url一定要配置好才不会出错。

### DIFF
--- a/user/_checkin.php
+++ b/user/_checkin.php
@@ -1,8 +1,14 @@
 <?php
 require_once '../lib/config.php';
 require_once '_check.php';
+//加入防签到系统平台，如果不是在用户中心点的签到都不会奖励流量。
+if($_SERVER['HTTP_REFERER']!=$site_url."user/index.php"){
+    $a['code'] = '0';
+    $a['msg'] = "非法访问";
+    write_log("user/checkin_error","非法访问",true,true);
+}
 //权限检查
-if(!$oo->is_able_to_check_in()){
+elseif(!$oo->is_able_to_check_in()){
     $transfer_to_add = 0;
 }else {
     if ($oo->unused_transfer() < 2048 * $tomb) {
@@ -15,4 +21,4 @@ if(!$oo->is_able_to_check_in()){
 }
 
 $a['msg'] = "获得了".$transfer_to_add."MB流量";
-echo json_encode($a);
+echo json_encode($a,JSON_UNESCAPED_UNICODE);

--- a/user/_login.php
+++ b/user/_login.php
@@ -9,8 +9,8 @@ $c = new \Ss\User\UserCheck();
 $q = new \Ss\User\Query();
 //加入防签到系统平台，如果不是在登录页点的登录，返回非法访问。
 if($_SERVER['HTTP_REFERER']!=$site_url."user/login.php"){
-    $a['code'] = '0';
-    $a['msg'] = "非法访问";
+    $rs['code'] = '0';
+    $rs['msg'] = "非法访问";
 }
 elseif($c->EmailLogin($email,$passwd)){
     $rs['code'] = '1';

--- a/user/_login.php
+++ b/user/_login.php
@@ -7,7 +7,12 @@ $passwd = \Ss\User\Comm::SsPW($passwd);
 $rem = $_POST['remember_me'];
 $c = new \Ss\User\UserCheck();
 $q = new \Ss\User\Query();
-if($c->EmailLogin($email,$passwd)){
+//加入防签到系统平台，如果不是在登录页点的登录，返回非法访问。
+if($_SERVER['HTTP_REFERER']!=$site_url."user/login.php"){
+    $a['code'] = '0';
+    $a['msg'] = "非法访问";
+}
+elseif($c->EmailLogin($email,$passwd)){
     $rs['code'] = '1';
     $rs['ok'] = '1';
     $rs['msg'] = "欢迎回来";
@@ -28,4 +33,4 @@ if($c->EmailLogin($email,$passwd)){
     $rs['code'] = '0';
     $rs['msg'] = "邮箱或者密码错误";
 }
-echo json_encode($rs);
+echo json_encode($rs,JSON_UNESCAPED_UNICODE);


### PR DESCRIPTION
加入防签到系统平台，如果不是在登录页点的登录，返回非法访问。
加入防签到系统平台，如果不是在用户中心点的签到都不会奖励流量。

加入这个的主要原因是，最近很多人都用签到系统平台，用户的活跃性下降不说，还有一些签到系统使用的是SQLite没有加密功能的，而且帐号密码什么都是明文保存的，一但被拖库，后果非常严重，为了保护用户帐号安全，只能先自已防止。