### PR TITLE
修复：tpl中的JS花括号被错误识别成php代码而导致的错误

### DIFF
--- a/resources/views/default/user/nodeinfo.tpl
+++ b/resources/views/default/user/nodeinfo.tpl
@@ -69,7 +69,9 @@
 
             <script src=" /assets/public/js/jquery.qrcode.min.js "></script>
             <script>
-                jQuery('#qrcode').qrcode({"text": "{$ssqr}"});
+                jQuery('#qrcode').qrcode({
+                    "text": "{$ssqr}"
+                });
             </script>
 
         </div>


### PR DESCRIPTION
`resources/views/default/user/nodeinfo.tpl`中生成QR的语句中有一对JS的花括号，但是和PHP的模板引擎中的花括号起了冲突，被识别为了模板引擎的花括号导致输出错误。
解决方法是，换行。改成多行。或者在花括号内添加一对空格。

不过这样不利于代码压缩。