### PR TITLE
Use codepoints of material icons to be compatible with old browsers

### DIFF
--- a/resources/views/default/header.tpl
+++ b/resources/views/default/header.tpl
@@ -38,6 +38,9 @@
                 <li><a href="/auth/register">注册</a></li>
             {/if}
         </ul>
-        <a href="#" data-activates="nav-mobile" class="button-collapse"><i class="material-icons">menu</i></a>
+        <!-- To be compatible with some old browsers(especially mobile browsers), use &#xE5D2 instead of menu. For more information visit the link below.
+         http://google.github.io/material-design-icons/#using-the-icons-in-html
+         -->
+        <a href="#" data-activates="nav-mobile" class="button-collapse"><i class="material-icons">&#xE5D2</i></a>
     </div>
 </nav>

--- a/resources/views/default/index.tpl
+++ b/resources/views/default/index.tpl
@@ -28,7 +28,10 @@
         <div class="row">
             <div class="col s12 m4">
                 <div class="icon-block">
-                    <h2 class="center light-blue-text"><i class="material-icons">flash_on</i></h2>
+                    <!-- To be compatible with some old browsers(especially mobile browsers), use &#xE3E7 instead of flash_on. For more information visit the link below.
+                    http://google.github.io/material-design-icons/#using-the-icons-in-html
+                    -->
+                    <h2 class="center light-blue-text"><i class="material-icons">&#xE3E7</i></h2>
                     <h5 class="center">Super Fast</h5>
 
                     <p class="light">
@@ -39,7 +42,10 @@
 
             <div class="col s12 m4">
                 <div class="icon-block">
-                    <h2 class="center light-blue-text"><i class="material-icons">group</i></h2>
+                    <!-- To be compatible with some old browsers(especially mobile browsers), use &#xE7EF instead of group. For more information visit the link below.
+                    http://google.github.io/material-design-icons/#using-the-icons-in-html
+                    -->
+                    <h2 class="center light-blue-text"><i class="material-icons">&#xE7EF</i></h2>
                     <h5 class="center">Open Source</h5>
 
                     <p class="light">
@@ -50,7 +56,10 @@
 
             <div class="col s12 m4">
                 <div class="icon-block">
-                    <h2 class="center light-blue-text"><i class="material-icons">settings</i></h2>
+                    <!-- To be compatible with some old browsers(especially mobile browsers), use &#xE8B8 instead of settings. For more information visit the link below.
+                    http://google.github.io/material-design-icons/#using-the-icons-in-html
+                    -->
+                    <h2 class="center light-blue-text"><i class="material-icons">&#xE8B8</i></h2>
                     <h5 class="center">Easy to work with</h5>
 
                     <p class="light">


### PR DESCRIPTION
In some old browsers, especially browsers on mobile phones. For example, 

> Mozilla/5.0 (Linux; U; Android 4.0.4; en-gb; GT-I9300 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30

, cannot display the material icons correctly.

In brief, since these browser are not so old like IE8, it will be friendlier to make it compatible with them. In fact, I have seen a lot of users using such browsers, on which most websites work correctly except this.
